### PR TITLE
Message notify callback seem to have unexpected behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ function showToast(win, title, content) {
 		wait: true
 	};
 
-	notifier.notify(message, () => win.focus());
+	notifier.notify(message);
+	notifier.on('click', () => win.focus());
 }
 
 function showBadge(win) {


### PR DESCRIPTION
When the notification closes on windows, the callback is invoked.

Solved by separating the onclick event from the message
